### PR TITLE
[MASTER] doc: make uniqBy & mergeBy instructions more precise

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Implement & write tests for the following functions
 
 ## uniqBy
 
-- [ ] it should deduplicate objects inside an array using the provided key
+- [ ] it should deduplicate objects inside an array using the provided key.
+  - the input array must not be mutated
+  - the order of the elements must be kept (i.e.: you cannot have Obi-Wan before Anakin) 
 
 ```js
 uniqBy('id', [
@@ -22,6 +24,8 @@ uniqBy('id', [
 ## mergeBy
 
 - [ ] `mergeBy` should merge two arrays of objects using a specified key
+  - the input arrays must not be mutated
+  - the order of the elements must be kept (i.e.: you cannot have Obi-Wan before Anakin/Darth Vader)
 
 ```js
 mergeBy(


### PR DESCRIPTION
# Context
In many interviews I've done, we always give the same oral instructions for `uniqBy` and `mergeBy` in addition to those in the README: 
- the input array(s) must not be mutated
- the order has to be kept

As discussed with @maximejimenez during the last interview, we think it's better to put them directly in the README.

# Content
This PR adds these two instructions in the README.